### PR TITLE
Feature/platform event publisher

### DIFF
--- a/force-app/main/default/classes/LogEventHandler.cls
+++ b/force-app/main/default/classes/LogEventHandler.cls
@@ -1,0 +1,15 @@
+public class LogEventHandler {
+    System.TriggerOperation operation = Trigger.operationType;
+    List<LogEvent__e> logEvents = Trigger.new;
+
+    public void run() {
+        if (this.operation == System.TriggerOperation.AFTER_INSERT) {
+            List<Log__c> logs = this.convertToLogs(this.logEvents);
+            Database.insert(logs, false);
+        }
+    }
+
+    private List<Log__c> convertToLogs(List<LogEvent__e> events) {
+        return (List<Log__c>) JSON.deserialize(JSON.serialize(events), List<Log__c>.class);
+    }
+}

--- a/force-app/main/default/classes/LogEventHandler.cls-meta.xml
+++ b/force-app/main/default/classes/LogEventHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/LogEventPublisher.cls
+++ b/force-app/main/default/classes/LogEventPublisher.cls
@@ -3,6 +3,11 @@ public class LogEventPublisher implements Logger.LogPublisher {
     static Integer numPublished = 0; 
     
     public void publish(List<Log__c> logs) {
-        // TODO!
+        List<LogEvent__e> events = (List<LogEvent__e>) JSON.deserialize(
+            JSON.serialize(logs), 
+            List<LogEvent__e>.class
+        );
+        EventBus.publish(events);
+        LogEventPublisher.numPublished += events?.size();
     }
 }

--- a/force-app/main/default/classes/LogEventPublisher.cls
+++ b/force-app/main/default/classes/LogEventPublisher.cls
@@ -1,8 +1,8 @@
-public class LogEventPublisher implements Logger.LogPublisher {
+global class LogEventPublisher implements Logger.LogPublisher {
     @TestVisible
     static Integer numPublished = 0; 
     
-    public void publish(List<Log__c> logs) {
+    global void publish(List<Log__c> logs) {
         List<LogEvent__e> events = (List<LogEvent__e>) JSON.deserialize(
             JSON.serialize(logs), 
             List<LogEvent__e>.class

--- a/force-app/main/default/classes/LogEventPublisher.cls
+++ b/force-app/main/default/classes/LogEventPublisher.cls
@@ -1,0 +1,8 @@
+public class LogEventPublisher implements Logger.LogPublisher {
+    @TestVisible
+    static Integer numPublished = 0; 
+    
+    public void publish(List<Log__c> logs) {
+        // TODO!
+    }
+}

--- a/force-app/main/default/classes/LogEventPublisher.cls-meta.xml
+++ b/force-app/main/default/classes/LogEventPublisher.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/LogEventPublisherTest.cls
+++ b/force-app/main/default/classes/LogEventPublisherTest.cls
@@ -1,0 +1,17 @@
+@IsTest 
+private class LogEventPublisherTest {
+    @IsTest 
+    static void shouldPublishLogs() {
+        List<Log__c> logs = new List<Log__c>();
+        for (Integer i = 0; i < 200; i++) {
+            Log__c log = new Log__c(); 
+            logs?.add(log); 
+        }
+        
+        Test.startTest();
+        new LogEventPublisher()?.publish(logs);
+        Test.stopTest();
+
+        Assert.areEqual(logs?.size(), LogEventPublisher.numPublished, 'Wrong # of Logs Published');
+    }
+}

--- a/force-app/main/default/classes/LogEventPublisherTest.cls
+++ b/force-app/main/default/classes/LogEventPublisherTest.cls
@@ -2,16 +2,16 @@
 private class LogEventPublisherTest {
     @IsTest 
     static void shouldPublishLogs() {
-        List<Log__c> logs = new List<Log__c>();
-        for (Integer i = 0; i < 200; i++) {
-            Log__c log = new Log__c(); 
-            logs?.add(log); 
+        LogTestUtils.enableLogging(System.LoggingLevel.FINEST);
+        Integer numLogs = Integer.valueOf(Math.random() * 10) + 1; 
+        for (Integer i = 0; i < numLogs; i++) {
+            new Logger().info('Hello world!'); 
         }
         
         Test.startTest();
-        new LogEventPublisher()?.publish(logs);
+        new LogEventPublisher()?.publish(Logger.pendingLogs);
         Test.stopTest();
 
-        Assert.areEqual(logs?.size(), LogEventPublisher.numPublished, 'Wrong # of Logs Published');
+        Assert.areEqual(numLogs, LogEventPublisher.numPublished, 'Wrong # of Logs Published');
     }
 }

--- a/force-app/main/default/classes/LogEventPublisherTest.cls-meta.xml
+++ b/force-app/main/default/classes/LogEventPublisherTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/LogEventTriggerTest.cls
+++ b/force-app/main/default/classes/LogEventTriggerTest.cls
@@ -1,0 +1,73 @@
+@IsTest 
+private class LogEventTriggerTest {
+    @IsTest 
+    static void shouldCreateLogs() {
+        for (Integer i = 0; i < 200; i++) {
+            new Logger().info('Hello world');
+        }
+        List<LogEvent__e> events = (List<LogEvent__e>) JSON.deserialize(
+            JSON.serialize(Logger.pendingLogs), 
+            List<LogEvent__e>.class
+        );
+
+        Test.startTest();
+        EventBus.publish(events);
+        Test.getEventBus()?.deliver();
+        Test.stopTest();
+
+        List<Log__c> logs = LogEventTriggerTest.getLogs();
+        Assert.areEqual(events?.size(), logs?.size(), 'Wrong # of Logs');
+    }
+
+    @IsTest 
+    static void shouldMapCorrectValues() {
+        LogEvent__e event = new LogEvent__e();
+        event.Body__c = 'testing 123';
+        event.Category__c = 'my category';
+        event.Context__c = 'my context';
+        event.Level__c = System.LoggingLevel.FINEST.name();
+        event.LoggedAt__c = DateTime.now();
+        event.LoggedBy__c = UserInfo.getUserId();
+        event.LoggedFrom__c = LogEventTriggerTest.class?.getName();
+        event.Ordinal__c = 100;
+        event.RelatedRecordId__c = '001' + '0'.repeat(15);
+        event.StackTrace__c = 'my stack trace';
+        event.Transaction__c = 'my transaction';
+        List<LogEvent__e> events = new List<LogEvent__e>{event};
+
+        Test.startTest();
+        EventBus.publish(events);
+        Test.getEventBus()?.deliver();
+        Test.stopTest();
+
+        List<Log__c> logs = LogEventTriggerTest.getLogs();
+        Assert.areEqual(events?.size(), logs?.size(), 'Wrong # of Logs');
+        Log__c log = logs[0];
+        Assert.areEqual(event?.Body__c, log?.Body__c, 'Wrong Body__c');
+        Assert.areEqual(event?.Category__c, log?.Category__c, 'Wrong Category__c');
+        Assert.areEqual(event?.Context__c, log?.Context__c, 'Wrong Context__c');
+        Assert.areEqual(event?.Level__c, log?.Level__c, 'Wrong Level__c');
+        Assert.areEqual(event?.LoggedAt__c, log?.LoggedAt__c, 'Wrong LoggedAt__c');
+        Assert.areEqual(event?.LoggedBy__c, log?.LoggedBy__c, 'Wrong LoggedBy__c');
+        Assert.areEqual(event?.LoggedFrom__c, log?.LoggedFrom__c, 'Wrong LoggedFrom__c');
+        Assert.areEqual(event?.Ordinal__c, log?.Ordinal__c, 'Wrong Ordinal__c');
+        Assert.areEqual(event?.RelatedRecordId__c, log?.RelatedRecordId__c, 'Wrong RelatedRecordId__c');
+        Assert.areEqual(event?.StackTrace__c, log?.StackTrace__c, 'Wrong StackTrace__c');
+        Assert.areEqual(event?.Transaction__c, log?.Transaction__c, 'Wrong Transaction__c');
+    }
+
+    // **** HELPER **** //
+    @TestSetup 
+    static void setup() {
+        LogTestUtils.enableLogging(System.LoggingLevel.FINEST);
+    }
+
+    static List<Log__c> getLogs() {
+        return [
+            SELECT 
+                Id, Body__c, Category__c, Context__c, Level__c, LoggedAt__c, LoggedBy__c, 
+                LoggedFrom__c, Ordinal__c, RelatedRecordId__c, StackTrace__c, Transaction__c
+            FROM Log__c
+        ];
+    }
+}

--- a/force-app/main/default/classes/LogEventTriggerTest.cls-meta.xml
+++ b/force-app/main/default/classes/LogEventTriggerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/objects/LogEvent__e/LogEvent__e.object-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/LogEvent__e.object-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Contains Log data to be inserted asynchronously, via its platform event trigger.
+Publish immediately behavior guarantees that logs published using this event will be captured, regardless of rollbacks and uncaught exceptions.</description>
+    <eventType>HighVolume</eventType>
+    <label>Log Event</label>
+    <pluralLabel>Log Events</pluralLabel>
+    <publishBehavior>PublishImmediately</publishBehavior>
+</CustomObject>

--- a/force-app/main/default/objects/LogEvent__e/fields/Body__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/Body__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Body__c</fullName>
+    <description>Maps to the Log field of the same name.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Body</label>
+    <length>131072</length>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/Category__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/Category__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Category__c</fullName>
+    <description>Contains an optional value which categorizes the log. Ex., a specific managed package, or a specific business process. Maps to the Log field of the same name.</description>
+    <externalId>false</externalId>
+    <label>Category</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/Context__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/Context__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Context__c</fullName>
+    <externalId>false</externalId>
+    <description>Details the current execution context when the log was generated. Maps to the Log field of the same name.
+Displays a System.Quiddity value: 
+https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_System_Quiddity.htm#topic-title</description>
+    <label>Context</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/Level__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/Level__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Level__c</fullName>
+    <externalId>false</externalId>
+    <description>Indicates the severity of the log message.  Maps to the Log field of the same name. Values are derived from the System.LoggingLevel enum:
+https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_enum_System_LoggingLevel.htm</description>
+    <label>Level</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/LoggedAt__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/LoggedAt__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LoggedAt__c</fullName>
+    <description>The Date/Time that the message was logged. This may differ slightly from the CreatedDate, depending on the publishing method. Maps to the Log field of the same name.</description>
+    <externalId>false</externalId>
+    <label>Logged At</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/LoggedBy__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/LoggedBy__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LoggedBy__c</fullName>
+    <description>Indicates the user that requested the Log. This may differ from the &quot;Created By&quot; user, if the log was published via platform event. Maps to the Log field of the same name.</description>
+    <externalId>false</externalId>
+    <label>Logged By</label>
+    <length>18</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/LoggedFrom__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/LoggedFrom__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LoggedFrom__c</fullName>
+    <description>The component (ex., Logged From) which spawned the current log record. Maps to the Log field of the same name.</description>
+    <externalId>false</externalId>
+    <label>Logged From</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/Ordinal__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/Ordinal__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Indicates the order in which logs in the same transaction were inserted (beginning with 1). Maps to the Log field of the same name.</description>
+    <fullName>Ordinal__c</fullName>
+    <externalId>false</externalId>
+    <label>Ordinal</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/RelatedRecordId__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/RelatedRecordId__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RelatedRecordId__c</fullName>
+    <description>The 18-digit Salesforce Id of the record most closely related to the current log. Maps to the Log field of the same name.</description>
+    <externalId>false</externalId>
+    <label>Related Record Id</label>
+    <length>18</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/StackTrace__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/StackTrace__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Maps to the Log field of the same name.</description>
+    <fullName>StackTrace__c</fullName>
+    <externalId>false</externalId>
+    <label>Stack Trace</label>
+    <length>131072</length>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/LogEvent__e/fields/Transaction__c.field-meta.xml
+++ b/force-app/main/default/objects/LogEvent__e/fields/Transaction__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Transaction__c</fullName>
+    <description>An identifier unique to each apex transaction. Use this to group logs from the same transaction together. Maps to the Log field of the same name.</description>
+    <externalId>false</externalId>
+    <label>Transaction</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/triggers/LogEventTrigger.trigger
+++ b/force-app/main/default/triggers/LogEventTrigger.trigger
@@ -1,0 +1,3 @@
+trigger LogEventTrigger on LogEvent__e (after insert) {
+    new LogEventHandler().run();
+}

--- a/force-app/main/default/triggers/LogEventTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/LogEventTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>58.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
Creates a new `Logger.LogPublisher` implementation: `LogEventPublisher`. This publisher uses a `LogEvent__e` platform event object, which has fields which exactly mirror the `Log__c` object. This allows for simple JSON serialization between the two types.

The LogEvent is published immediately, which means it isn't bound by rollbacks - whether manual, or through uncaught exceptions. This can be leveraged to publish logs in `catch` blocks, but still allow the transaction to fail properly. 