### PR TITLE
Feature/adjust publisher invocable

### DIFF
--- a/force-app/main/default/classes/InvocableLogPublisher.cls
+++ b/force-app/main/default/classes/InvocableLogPublisher.cls
@@ -19,7 +19,7 @@ global abstract class InvocableLogPublisher {
 	}
 
 	global class Input {
-		@InvocableVariable(label='Publisher Class' required=true)
+		@InvocableVariable(label='Publisher Class' required=false)
 		global String publisher;
 
 		private Logger.LogPublisher getPublisher() {

--- a/force-app/main/default/classes/InvocableLogPublisher.cls
+++ b/force-app/main/default/classes/InvocableLogPublisher.cls
@@ -1,4 +1,6 @@
 global abstract class InvocableLogPublisher {
+	static final Logger META_LOGGER = new Logger().setLoggedFrom(InvocableLogPublisher.class);
+
 	@InvocableMethod(category='Logging' label='Publish Logs')
 	global static void invoke(List<Input> inputs) {
 		Logger.LogPublisher publisher; 
@@ -7,18 +9,16 @@ global abstract class InvocableLogPublisher {
 				publisher = (Logger.LogPublisher) Type.forName(input?.publisherName)?.newInstance();
 				if (publisher != null) {
 					break;
+				} else {
+					throw new System.NoSuchElementException();
 				}
 			} catch (Exception error) {
-				// Nothing for now
+				META_LOGGER?.warn(input?.publisherName + ' is not a valid instance of Logger.LogPublisher');
 			}
 		}
-		if (publisher != null) {
-			// Use the publisher!
-			new Logger().publish(publisher);
-		} else {
-			// Use the default publisher
-			new Logger()?.publish();
-		}
+		Logger logger = (publisher != null) 
+			? new Logger()?.publish(publisher) 
+			: new Logger().publish();
 	}
 
 	global class Input {

--- a/force-app/main/default/classes/InvocableLogPublisher.cls
+++ b/force-app/main/default/classes/InvocableLogPublisher.cls
@@ -3,26 +3,29 @@ global abstract class InvocableLogPublisher {
 
 	@InvocableMethod(category='Logging' label='Publish Logs')
 	global static void invoke(List<Input> inputs) {
-		Logger.LogPublisher publisher; 
+		// Iterate through the inputs and retrieve the first valid LogPublisher
+		// Then use this publisher to publish any pending logs
 		for (Input input : inputs) {
-			try {
-				publisher = (Logger.LogPublisher) Type.forName(input?.publisherName)?.newInstance();
-				if (publisher != null) {
-					break;
-				} else {
-					throw new System.NoSuchElementException();
-				}
-			} catch (Exception error) {
+			Logger.LogPublisher publisher = input?.getPublisher();
+			if (publisher != null) {
+				new Logger().publish(publisher);
+				break; 
+			} else {
 				META_LOGGER?.warn(input?.publisherName + ' is not a valid instance of Logger.LogPublisher');
 			}
 		}
-		Logger logger = (publisher != null) 
-			? new Logger()?.publish(publisher) 
-			: new Logger().publish();
+		// If the logs are still unpublished, use the default publisher
+		new Logger().publish();
 	}
 
 	global class Input {
 		@InvocableVariable 
 		global String publisherName;
+
+		private Logger.LogPublisher getPublisher() {
+			return String.isNotBlank(this.publisherName)
+				? (Logger.LogPublisher) Type.forName(this.publisherName)?.newInstance()
+				: Logger.DEFAULT_PUBLISHER;
+		}
 	}
 }

--- a/force-app/main/default/classes/InvocableLogPublisher.cls
+++ b/force-app/main/default/classes/InvocableLogPublisher.cls
@@ -11,7 +11,7 @@ global abstract class InvocableLogPublisher {
 				new Logger().publish(publisher);
 				break; 
 			} else {
-				META_LOGGER?.warn(input?.publisherName + ' is not a valid instance of Logger.LogPublisher');
+				META_LOGGER?.warn(input?.publisher + ' is not a valid instance of Logger.LogPublisher');
 			}
 		}
 		// If the logs are still unpublished, use the default publisher
@@ -19,12 +19,12 @@ global abstract class InvocableLogPublisher {
 	}
 
 	global class Input {
-		@InvocableVariable 
-		global String publisherName;
+		@InvocableVariable(label='Publisher Class' required=true)
+		global String publisher;
 
 		private Logger.LogPublisher getPublisher() {
-			return String.isNotBlank(this.publisherName)
-				? (Logger.LogPublisher) Type.forName(this.publisherName)?.newInstance()
+			return String.isNotBlank(this.publisher)
+				? (Logger.LogPublisher) Type.forName(this.publisher)?.newInstance()
 				: Logger.DEFAULT_PUBLISHER;
 		}
 	}

--- a/force-app/main/default/classes/InvocableLogPublisher.cls
+++ b/force-app/main/default/classes/InvocableLogPublisher.cls
@@ -1,6 +1,28 @@
 global abstract class InvocableLogPublisher {
 	@InvocableMethod(category='Logging' label='Publish Logs')
-	global static void invoke() {
-		new Logger()?.publish();
+	global static void invoke(List<Input> inputs) {
+		Logger.LogPublisher publisher; 
+		for (Input input : inputs) {
+			try {
+				publisher = (Logger.LogPublisher) Type.forName(input?.publisherName)?.newInstance();
+				if (publisher != null) {
+					break;
+				}
+			} catch (Exception error) {
+				// Nothing for now
+			}
+		}
+		if (publisher != null) {
+			// Use the publisher!
+			new Logger().publish(publisher);
+		} else {
+			// Use the default publisher
+			new Logger()?.publish();
+		}
+	}
+
+	global class Input {
+		@InvocableVariable 
+		global String publisherName;
 	}
 }

--- a/force-app/main/default/classes/InvocableLogPublisherTest.cls
+++ b/force-app/main/default/classes/InvocableLogPublisherTest.cls
@@ -48,15 +48,38 @@ private class InvocableLogPublisherTest {
 	}
 
 	@IsTest 
+	static void shouldUseFirstInputValue() {
+		// Because of the way Flow bulkification works, record-triggered flows produce 1 Input object for each record 
+		// However, we shouldn't publish more than once; instead, take the first valid publisher and use it
+		new Logger().error('This is a test');
+		List<InvocableLogPublisher.Input> inputs = new List<InvocableLogPublisher.Input>();
+		for (String publisher : new List<String>{ 
+			LogEventPublisher.class.getName(), 
+			LogDmlPublisher.class.getName() 
+		}) {
+			InvocableLogPublisher.Input input = new InvocableLogPublisher.Input(); 
+			input.publisherName = publisher;
+			inputs?.add(input);
+		}
+		
+		Test.startTest();
+		InvocableLogPublisher.invoke(inputs);
+		Assert.areEqual(1, Limits.getPublishImmediateDml(), 'Wrong # of Platform Event Publishes');
+		Assert.areEqual(0, Limits.getDmlStatements(), 'Wrong # of DML statements');
+		Test.stopTest();
+
+		Assert.areEqual(1, LogEventPublisher.numPublished, 'Wrong # of Logs Published via LogEventPublisher');
+	}
+
+	@IsTest 
 	static void shouldUseFirstValidInputValue() {
 		// Because of the way Flow bulkification works, record-triggered flows produce 1 Input object for each record 
 		// However, we shouldn't publish more than once; instead, take the first valid publisher and use it
 		new Logger().error('This is a test');
 		List<InvocableLogPublisher.Input> inputs = new List<InvocableLogPublisher.Input>();
 		for (String publisher : new List<String>{ 
-			'abcd1234', 
-			LogEventPublisher.class.getName(), 
-			LogDmlPublisher.class.getName() 
+			'abcd1234',
+			LogEventPublisher.class.getName()
 		}) {
 			InvocableLogPublisher.Input input = new InvocableLogPublisher.Input(); 
 			input.publisherName = publisher;

--- a/force-app/main/default/classes/InvocableLogPublisherTest.cls
+++ b/force-app/main/default/classes/InvocableLogPublisherTest.cls
@@ -1,17 +1,78 @@
 @IsTest
 private class InvocableLogPublisherTest {
-	@IsTest
-	static void shouldPublish() {
+	@IsTest 
+	static void shouldPublishWithSpecificPublisher() {
 		new Logger().error('This is a test');
+		InvocableLogPublisher.Input input = new InvocableLogPublisher.Input();
+		input.publisherName = LogEventPublisher.class.getName();
 
 		Test.startTest();
-		InvocableLogPublisher.invoke();
+		InvocableLogPublisher.invoke(new List<InvocableLogPublisher.Input>{input});
+		Test.getEventBus()?.deliver();
+		Test.stopTest();
+
+		Assert.areEqual(1, LogEventPublisher.numPublished, 'Wrong # of Logs Published via LogEventPublisher');
+		List<Log__c> logs = [SELECT Id FROM Log__c];
+		Assert.areEqual(1, logs?.size(), 'Wrong # of logs');
+	}
+
+	@IsTest
+	static void shouldUseDefaultPublisherIfNullProvider() {
+		// If the publisher value is missing, use the default publisher defined by the user's LogSetting__c,
+		new Logger().error('This is a test');
+		InvocableLogPublisher.Input input = new InvocableLogPublisher.Input();
+		input.publisherName = null;
+
+		Test.startTest();
+		InvocableLogPublisher.invoke(new List<InvocableLogPublisher.Input>{input});
 		Test.stopTest();
 
 		List<Log__c> logs = [SELECT Id FROM Log__c];
 		Assert.areEqual(1, logs?.size(), 'Wrong # of logs');
 	}
 
+	@IsTest 
+	static void shouldUseDefaultPublisherIfInvalidProvider() {
+		// If the publisher value doesn't match an existing Logger.LogPublisher, 
+		// use the default publisher defined by the user's LogSetting__c,
+		new Logger().error('This is a test');
+		InvocableLogPublisher.Input input = new InvocableLogPublisher.Input();
+		input.publisherName = 'abcd1234';
+
+		Test.startTest();
+		InvocableLogPublisher.invoke(new List<InvocableLogPublisher.Input>{input});
+		Test.stopTest();
+
+		List<Log__c> logs = [SELECT Id FROM Log__c];
+		Assert.areEqual(1, logs?.size(), 'Wrong # of logs');
+	}
+
+	@IsTest 
+	static void shouldUseFirstValidInputValue() {
+		// Because of the way Flow bulkification works, record-triggered flows produce 1 Input object for each record 
+		// However, we shouldn't publish more than once; instead, take the first valid publisher and use it
+		new Logger().error('This is a test');
+		List<InvocableLogPublisher.Input> inputs = new List<InvocableLogPublisher.Input>();
+		for (String publisher : new List<String>{ 
+			'abcd1234', 
+			LogEventPublisher.class.getName(), 
+			LogDmlPublisher.class.getName() 
+		}) {
+			InvocableLogPublisher.Input input = new InvocableLogPublisher.Input(); 
+			input.publisherName = publisher;
+			inputs?.add(input);
+		}
+		
+		Test.startTest();
+		InvocableLogPublisher.invoke(inputs);
+		Assert.areEqual(1, Limits.getPublishImmediateDml(), 'Wrong # of Platform Event Publishes');
+		Assert.areEqual(0, Limits.getDmlStatements(), 'Wrong # of DML statements');
+		Test.stopTest();
+
+		Assert.areEqual(1, LogEventPublisher.numPublished, 'Wrong # of Logs Published via LogEventPublisher');
+	}
+
+	// **** HELPER **** //
 	@TestSetup
 	static void setup() {
 		LogTestUtils.enableLogging(System.LoggingLevel.FINEST);

--- a/force-app/main/default/classes/InvocableLogPublisherTest.cls
+++ b/force-app/main/default/classes/InvocableLogPublisherTest.cls
@@ -4,7 +4,7 @@ private class InvocableLogPublisherTest {
 	static void shouldPublishWithSpecificPublisher() {
 		new Logger().error('This is a test');
 		InvocableLogPublisher.Input input = new InvocableLogPublisher.Input();
-		input.publisherName = LogEventPublisher.class.getName();
+		input.publisher = LogEventPublisher.class.getName();
 
 		Test.startTest();
 		InvocableLogPublisher.invoke(new List<InvocableLogPublisher.Input>{input});
@@ -21,7 +21,7 @@ private class InvocableLogPublisherTest {
 		// If the publisher value is missing, use the default publisher defined by the user's LogSetting__c,
 		new Logger().error('This is a test');
 		InvocableLogPublisher.Input input = new InvocableLogPublisher.Input();
-		input.publisherName = null;
+		input.publisher = null;
 
 		Test.startTest();
 		InvocableLogPublisher.invoke(new List<InvocableLogPublisher.Input>{input});
@@ -41,7 +41,7 @@ private class InvocableLogPublisherTest {
 		update settings;
 		new Logger().error('This is a test');
 		InvocableLogPublisher.Input input = new InvocableLogPublisher.Input();
-		input.publisherName = 'abcd1234';
+		input.publisher = 'abcd1234';
 
 		Test.startTest();
 		InvocableLogPublisher.invoke(new List<InvocableLogPublisher.Input>{input});
@@ -76,7 +76,7 @@ private class InvocableLogPublisherTest {
 			LogDmlPublisher.class.getName() 
 		}) {
 			InvocableLogPublisher.Input input = new InvocableLogPublisher.Input(); 
-			input.publisherName = publisher;
+			input.publisher = publisher;
 			inputs?.add(input);
 		}
 		
@@ -100,7 +100,7 @@ private class InvocableLogPublisherTest {
 			LogEventPublisher.class.getName()
 		}) {
 			InvocableLogPublisher.Input input = new InvocableLogPublisher.Input(); 
-			input.publisherName = publisher;
+			input.publisher = publisher;
 			inputs?.add(input);
 		}
 		
@@ -122,7 +122,7 @@ private class InvocableLogPublisherTest {
 			LogEventPublisher.class.getName()
 		}) {
 			InvocableLogPublisher.Input input = new InvocableLogPublisher.Input(); 
-			input.publisherName = publisher;
+			input.publisher = publisher;
 			inputs?.add(input);
 		}
 		

--- a/force-app/main/default/classes/InvocableLogPublisherTest.cls
+++ b/force-app/main/default/classes/InvocableLogPublisherTest.cls
@@ -34,7 +34,11 @@ private class InvocableLogPublisherTest {
 	@IsTest 
 	static void shouldUseDefaultPublisherIfInvalidProvider() {
 		// If the publisher value doesn't match an existing Logger.LogPublisher, 
-		// use the default publisher defined by the user's LogSetting__c,
+		// use the default publisher defined by the user's LogSetting__c.
+		// Also: post a warning log, that the defined publisher does not exist
+		LogSetting__c settings = LogSetting__c.getInstance();
+		settings.Threshold__c = System.LoggingLevel.WARN.name();
+		update settings;
 		new Logger().error('This is a test');
 		InvocableLogPublisher.Input input = new InvocableLogPublisher.Input();
 		input.publisherName = 'abcd1234';
@@ -43,8 +47,22 @@ private class InvocableLogPublisherTest {
 		InvocableLogPublisher.invoke(new List<InvocableLogPublisher.Input>{input});
 		Test.stopTest();
 
-		List<Log__c> logs = [SELECT Id FROM Log__c];
-		Assert.areEqual(1, logs?.size(), 'Wrong # of logs');
+		Map<String, List<Log__c>> logsByLevel = new Map<String, List<Log__c>>(); 
+		for (Log__c log : [SELECT Id, Level__c FROM Log__c]) {
+			String level = log?.Level__c;
+			List<Log__c> matching = logsByLevel?.containsKey(level)
+				? logsByLevel?.get(level)
+				: new List<Log__c>();
+			matching?.add(log);
+			logsByLevel?.put(level, matching);
+		}
+		Assert.areEqual(2, logsByLevel?.size(), 'Wrong # of logs');
+		for (System.LoggingLevel level : new List<System.LoggingLevel>{
+			System.LoggingLevel.ERROR, 
+			System.LoggingLevel.WARN
+		}) {
+			Assert.areEqual(1, logsByLevel?.get(level?.name())?.size(), 'Wrong # of ' + level + ' logs');
+		}
 	}
 
 	@IsTest 
@@ -98,6 +116,6 @@ private class InvocableLogPublisherTest {
 	// **** HELPER **** //
 	@TestSetup
 	static void setup() {
-		LogTestUtils.enableLogging(System.LoggingLevel.FINEST);
+		LogTestUtils.enableLogging(System.LoggingLevel.ERROR);
 	}
 }

--- a/force-app/main/default/classes/InvocableLogPublisherTest.cls
+++ b/force-app/main/default/classes/InvocableLogPublisherTest.cls
@@ -113,6 +113,28 @@ private class InvocableLogPublisherTest {
 		Assert.areEqual(1, LogEventPublisher.numPublished, 'Wrong # of Logs Published via LogEventPublisher');
 	}
 
+	@IsTest 
+	static void shouldTreatNullAsDefaultProvider() {
+		new Logger().error('This is a test');
+		List<InvocableLogPublisher.Input> inputs = new List<InvocableLogPublisher.Input>();
+		for (String publisher : new List<String>{ 
+			null,
+			LogEventPublisher.class.getName()
+		}) {
+			InvocableLogPublisher.Input input = new InvocableLogPublisher.Input(); 
+			input.publisherName = publisher;
+			inputs?.add(input);
+		}
+		
+		Test.startTest();
+		InvocableLogPublisher.invoke(inputs);
+		Assert.areEqual(0, Limits.getPublishImmediateDml(), 'Wrong # of Platform Event Publishes');
+		Assert.areEqual(1, Limits.getDmlStatements(), 'Wrong # of DML statements');
+		Test.stopTest();
+
+		Assert.areEqual(0, LogEventPublisher.numPublished, 'Wrong # of Logs Published via LogEventPublisher');
+	}
+
 	// **** HELPER **** //
 	@TestSetup
 	static void setup() {

--- a/force-app/main/default/classes/Logger.cls
+++ b/force-app/main/default/classes/Logger.cls
@@ -1,6 +1,6 @@
 global without sharing virtual class Logger {
 	// Constants
-	static final LogPublisher DEFAULT_PUBLISHER = Logger.getDefaultPublisher();
+	public static final LogPublisher DEFAULT_PUBLISHER = Logger.getDefaultPublisher();
 	static final Integer LONG_TEXT_LENGTH = Log__c.Body__c?.getDescribe()?.getLength();
 	static final Integer SHORT_TEXT_LENGTH = Log__c.Category__c?.getDescribe()?.getLength();
 	static final System.Quiddity QUIDDITY = System.Request.getCurrent()?.getQuiddity();


### PR DESCRIPTION
**Important**: This is a **breaking change**. Subscribers who use version 1.1.0 will not be able to install until they remove any flows which used the old `InvocableLogPublisher.invoke()` action. 

The new action adds an optional `Publisher Class` parameter to the invocable. This is a string value which should correspond to the fully qualified API name of a class which implements the `Logger.LogPublisher` interface.

The invocable action attempts to generate a `Logger.LogPublisher` object using the `List<Input>` it receives. It will use the first valid publisher object it finds. If no `Input`s have a valid `publisher`, the default publisher (as defined in custom settings) is used instead.

Note: `null`/blank values can also be used when the default publisher is desired.